### PR TITLE
Select available pool when create volume

### DIFF
--- a/pkg/controller/selector/selector.go
+++ b/pkg/controller/selector/selector.go
@@ -85,6 +85,7 @@ func (s *selector) SelectSupportedPoolForVolume(vol *model.VolumeSpec) (*model.S
 			filterRequest["id"] = vol.PoolId
 		}
 		filterRequest["storageType"] = prf.StorageType
+		filterRequest["status"] = "available"
 		// Insert some rules of provisioning properties.
 		if pp := prf.ProvisioningProperties; !pp.IsEmpty() {
 			if ds := pp.DataStorage; !ds.IsEmpty() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Select a available pool when create volume
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
Now you can't create volume on a unavailable pool, which was allowed in previous version.
```release-note
[root@master-node opensds]# osdsctl pool list
+--------------------------------------+-----------------+-------------+-------------+---------------+--------------+
| Id                                   | Name            | Description | Status      | TotalCapacity | FreeCapacity |
+--------------------------------------+-----------------+-------------+-------------+---------------+--------------+
| e94ebaca-76be-56c7-aa12-b348632cc30f | StoragePool002  |             | unavailable | 40            | 36           |
+--------------------------------------+-----------------+-------------+-------------+---------------+--------------+
[root@master-node opensds]# osdsctl volume create 1 --name=test-001
+------------------+--------------------------------------+
| Property         | Value                                |
+------------------+--------------------------------------+
| Id               | 3162a008-f1f1-4e14-b270-f9a0d80d53bc |
| CreatedAt        | 2020-01-01T12:09:44                  |
| Name             | test-001                             |
| Description      |                                      |
| GroupId          |                                      |
| Size             | 1                                    |
| AvailabilityZone | default                              |
| Status           | creating                             |
| PoolId           |                                      |
| ProfileId        | 85bf0d5b-f0ed-4573-ac1d-a21d61402bf9 |
| Metadata         | null                                 |
|                  |                                      |
| MultiAttach      | false                                |
+------------------+--------------------------------------+
[root@master-node opensds]# osdsctl volume list
+--------------------------------------+----------+-------------+------+------------------+--------+--------------------------------------+
| Id                                   | Name     | Description | Size | AvailabilityZone | Status | ProfileId                            |
+--------------------------------------+----------+-------------+------+------------------+--------+--------------------------------------+
| 3162a008-f1f1-4e14-b270-f9a0d80d53bc | test-001 |             | 1    | default          | error  | 85bf0d5b-f0ed-4573-ac1d-a21d61402bf9 |
+--------------------------------------+----------+-------------+------+------------------+--------+--------------------------------------+

```
