### PR TITLE
Avoid unexpected errorDeleting

### DIFF
--- a/contrib/drivers/huawei/oceanstor/client.go
+++ b/contrib/drivers/huawei/oceanstor/client.go
@@ -303,6 +303,10 @@ func (c *OceanStorClient) GetVolumeByName(name string) (*Lun, error) {
 }
 func (c *OceanStorClient) DeleteVolume(id string) error {
 	err := c.request("DELETE", "/lun/"+id, nil, nil)
+	// If the lun already doesn't exist, delete command should not return err
+	if c.checkErrorCode(err, ErrorLunNotExist) {
+		return nil
+	}
 	return err
 }
 

--- a/contrib/drivers/huawei/oceanstor/constants.go
+++ b/contrib/drivers/huawei/oceanstor/constants.go
@@ -62,6 +62,7 @@ const (
 	ErrorObjectIDNotUnique             = 1077948997
 	ErrorHostGroupAlreadyInMappingView = 1073804556
 	ErrorLunGroupAlreadyInMappingView  = 1073804560
+	ErrorLunNotExist                   = 1077936859
 )
 
 // misc


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When deleting a volume on opensds, if the volume does actually not exist on storage device any more, the deleting procedure should be done successfully.

**Which issue this PR fixes** : fixes #1158

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
The volume which is actually not exist on storage device can be deleted.
```release-note
[root@master-node opensds]# osdsctl volume list
+--------------------------------------+----------+-------------+------+------------------+---------------+--------------------------------------+
| Id                                   | Name     | Description | Size | AvailabilityZone | Status        | ProfileId                            |
+--------------------------------------+----------+-------------+------+------------------+---------------+--------------------------------------+
| 88679417-d3e1-410c-91d8-ce3d43c9e215 | test-001 |             | 1    | default          | errorDeleting | a85796ce-e379-48e0-8bcd-f2583cf10d08 |
+--------------------------------------+----------+-------------+------+------------------+---------------+--------------------------------------+
[root@master-node opensds]# osdsctl volume delete 88679417-d3e1-410c-91d8-ce3d43c9e215
[root@master-node opensds]# osdsctl volume list
+----+------+-------------+------+--------+-----------+------------------+
| Id | Name | Description | Size | Status | ProfileId | AvailabilityZone |
+----+------+-------------+------+--------+-----------+------------------+
+----+------+-------------+------+--------+-----------+------------------+
[root@master-node opensds]#
```
