### PR TITLE
Enable thick and thin configuration for OceanStor

### DIFF
--- a/contrib/drivers/huawei/oceanstor/client.go
+++ b/contrib/drivers/huawei/oceanstor/client.go
@@ -222,12 +222,17 @@ func (c *OceanStorClient) logout() error {
 	return c.request("DELETE", "/sessions", nil, nil)
 }
 
-func (c *OceanStorClient) CreateVolume(name string, size int64, desc string, poolId string) (*Lun, error) {
+func (c *OceanStorClient) CreateVolume(name string, size int64, desc string, poolId string, provPolicy string) (*Lun, error) {
+	// default alloc type is thick
+	allocType := ThickLunType
+	if provPolicy == "Thin" {
+		allocType = ThinLunType
+	}
 	data := map[string]interface{}{
 		"NAME":        name,
 		"CAPACITY":    Gb2Sector(size),
 		"DESCRIPTION": desc,
-		"ALLOCTYPE":   ThinLunType,
+		"ALLOCTYPE":   allocType,
 		"PARENTID":    poolId,
 		"WRITEPOLICY": 1,
 	}

--- a/contrib/drivers/huawei/oceanstor/oceanstor.go
+++ b/contrib/drivers/huawei/oceanstor/oceanstor.go
@@ -76,8 +76,12 @@ func (d *Driver) createVolumeFromSnapshot(opt *pb.CreateVolumeOpts) (*model.Volu
 		return nil, err1
 	}
 
+	provPolicy := d.conf.Pool[opt.GetPoolName()].Extras.DataStorage.ProvisioningPolicy
+	if provPolicy == "" {
+		provPolicy = "Thick"
+	}
 	lun, err := d.client.CreateVolume(EncodeName(opt.GetId()), opt.GetSize(),
-		volumeDesc, poolId)
+		volumeDesc, poolId, provPolicy)
 	if err != nil {
 		log.Error("Create Volume Failed:", err)
 		return nil, err
@@ -168,7 +172,11 @@ func (d *Driver) CreateVolume(opt *pb.CreateVolumeOpts) (*model.VolumeSpec, erro
 	if err != nil {
 		return nil, err
 	}
-	lun, err := d.client.CreateVolume(name, opt.GetSize(), desc, poolId)
+	provPolicy := d.conf.Pool[opt.GetPoolName()].Extras.DataStorage.ProvisioningPolicy
+	if provPolicy == "" {
+		provPolicy = "Thick"
+	}
+	lun, err := d.client.CreateVolume(name, opt.GetSize(), desc, poolId, provPolicy)
 	if err != nil {
 		log.Error("Create Volume Failed:", err)
 		return nil, err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Enable thick and thin configuration for OceanStor

**Which issue this PR fixes** : fixes #1160

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1 Configure the provisioningPolicy to Thick, then create a volume, check the lun type in device, it is thick:
dataStorage:
  provisioningPolicy: Thick
  isSpaceEfficient: false
2. Configure the provisioningPolicy to Thin, then create a volume, check the lun type in device, it is Thin:
dataStorage:
  provisioningPolicy: Thin
  isSpaceEfficient: false
3. Do not configure the provisioningPolicy, then create a volume, check the lun type in device, it is the default type(Thick):
dataStorage:
  isSpaceEfficient: false
```
