### PR TITLE
Add prefix for etcd

### DIFF
--- a/pkg/utils/urls/urls.go
+++ b/pkg/utils/urls/urls.go
@@ -25,7 +25,7 @@ const (
 	Client        // Client == 1
 )
 
-const etcd_prefix string = "opensds"
+const etcd_prefix string = "/opensds"
 
 func GenerateHostURL(urlType int, tenantId string, in ...string) string {
 	return generateURL("host/hosts", urlType, tenantId, in...)

--- a/pkg/utils/urls/urls.go
+++ b/pkg/utils/urls/urls.go
@@ -25,6 +25,8 @@ const (
 	Client        // Client == 1
 )
 
+const etcd_prefix string = "opensds"
+
 func GenerateHostURL(urlType int, tenantId string, in ...string) string {
 	return generateURL("host/hosts", urlType, tenantId, in...)
 }
@@ -81,7 +83,12 @@ func GenerateVolumeGroupURL(urlType int, tenantId string, in ...string) string {
 func generateURL(resource string, urlType int, tenantId string, in ...string) string {
 	// If project id is not specified, ignore it.
 	if tenantId == "" {
-		value := []string{CurrentVersion(), resource}
+		var value []string
+		if urlType == Etcd {
+			value = []string{etcd_prefix, CurrentVersion(), resource}
+		} else {
+			value = []string{CurrentVersion(), resource}
+		}
 		value = append(value, in...)
 		return strings.Join(value, "/")
 	}
@@ -89,7 +96,7 @@ func generateURL(resource string, urlType int, tenantId string, in ...string) st
 	// Set project id after resource url just for etcd query performance.
 	var value []string
 	if urlType == Etcd {
-		value = []string{CurrentVersion(), resource, tenantId}
+		value = []string{etcd_prefix, CurrentVersion(), resource, tenantId}
 	} else {
 		value = []string{CurrentVersion(), tenantId, resource}
 	}

--- a/pkg/utils/urls/urls_test.go
+++ b/pkg/utils/urls/urls_test.go
@@ -27,24 +27,24 @@ func TestCurrentVersion(t *testing.T) {
 }
 
 func TestGenerateURL(t *testing.T) {
-	var expected = "v1beta/docks/d3c7e0c7-6e92-406c-9767-3ab73b39b64f"
+	var expected = "/opensds/v1beta/docks/d3c7e0c7-6e92-406c-9767-3ab73b39b64f"
 	if url := generateURL("docks", Etcd, "d3c7e0c7-6e92-406c-9767-3ab73b39b64f"); url != expected {
 		t.Errorf("Expected %v, got %v\n", expected, url)
 	}
-	expected = "v1beta/docks"
+	expected = "/opensds/v1beta/docks"
 	if url := generateURL("docks", Etcd, ""); url != expected {
 		t.Errorf("Expected %v, got %v\n", expected, url)
 	}
-	expected = "v1beta/pools/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/8e5e92ca-d673-11e7-bca8-2ba95b86eb06"
+	expected = "/opensds/v1beta/pools/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/8e5e92ca-d673-11e7-bca8-2ba95b86eb06"
 	if url := generateURL("pools", Etcd, "d3c7e0c7-6e92-406c-9767-3ab73b39b64f", "8e5e92ca-d673-11e7-bca8-2ba95b86eb06"); url != expected {
 		t.Errorf("Expected %v, got %v\n", expected, url)
 	}
 
-	expected = "v1beta/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/docks"
+	expected = "/opensds/v1beta/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/docks"
 	if url := generateURL("docks", Client, "d3c7e0c7-6e92-406c-9767-3ab73b39b64f"); url != expected {
 		t.Errorf("Expected %v, got %v\n", expected, url)
 	}
-	expected = "v1beta/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/pools/8e5e92ca-d673-11e7-bca8-2ba95b86eb06"
+	expected = "/opensds/v1beta/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/pools/8e5e92ca-d673-11e7-bca8-2ba95b86eb06"
 	if url := generateURL("pools", Client, "d3c7e0c7-6e92-406c-9767-3ab73b39b64f", "8e5e92ca-d673-11e7-bca8-2ba95b86eb06"); url != expected {
 		t.Errorf("Expected %v, got %v\n", expected, url)
 	}

--- a/pkg/utils/urls/urls_test.go
+++ b/pkg/utils/urls/urls_test.go
@@ -40,11 +40,11 @@ func TestGenerateURL(t *testing.T) {
 		t.Errorf("Expected %v, got %v\n", expected, url)
 	}
 
-	expected = "/opensds/v1beta/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/docks"
+	expected = "v1beta/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/docks"
 	if url := generateURL("docks", Client, "d3c7e0c7-6e92-406c-9767-3ab73b39b64f"); url != expected {
 		t.Errorf("Expected %v, got %v\n", expected, url)
 	}
-	expected = "/opensds/v1beta/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/pools/8e5e92ca-d673-11e7-bca8-2ba95b86eb06"
+	expected = "v1beta/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/pools/8e5e92ca-d673-11e7-bca8-2ba95b86eb06"
 	if url := generateURL("pools", Client, "d3c7e0c7-6e92-406c-9767-3ab73b39b64f", "8e5e92ca-d673-11e7-bca8-2ba95b86eb06"); url != expected {
 		t.Errorf("Expected %v, got %v\n", expected, url)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Nowadays our etcd key starting with "v1beta", which is not too special to avoid conflicting with other app which use the same etcd. So we should add a special prefix to avoid conflict.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
root@ceph-rgw:/opt/opensds/etcd-v3.3.10-linux-amd64 # ETCDCTL_API=3 ./etcdctl --endpoints=10.10.3.111:62379 --user=opensds:opensds@123 get --from-key 'opensds' -w=fields | grep Key
"Key" : "opensds/v1beta/block/volumes/e93b4c0934da416eb9c8d120c5d04d96/9f140b2e-0db6-4d41-a806-d60ac84d64ab"
"Key" : "opensds/v1beta/docks/8fc7de3b-7a7e-544d-b800-02c82922d9ee"
"Key" : "opensds/v1beta/docks/ab9e6613-04bb-5adb-ba32-b3611a3e7528"
"Key" : "opensds/v1beta/pools/2fd968c6-ef5f-5f90-aefc-6658c756b9ef"
"Key" : "opensds/v1beta/pools/55cfda0a-7363-5464-9198-bbe2137ed39b"
"Key" : "opensds/v1beta/profiles/f549a972-228f-4913-9c56-77d3612b5d5e"
root@ceph-rgw:/opt/opensds/etcd-v3.3.10-linux-amd64 #
```
